### PR TITLE
OWH-2244 Hover over tooltip incorrect for Age Adjusted Death Rate in …

### DIFF
--- a/software/owh/client/app/components/owh-table/owh-table.component.js
+++ b/software/owh/client/app/components/owh-table/owh-table.component.js
@@ -118,8 +118,8 @@
                             cell += '<div id="crudeRateDiv" class="owh-table__left-col usa-width-one-half">'
                             if(rowIndex === 0) {
                                 var rateLabel = { 'crude_death_rates': 'Crude Death Rate', 'age-adjusted_death_rates': 'Age Adjusted Death Rate', 'birth_rates':'Birth Rate', 'fertility_rates':'Fertility Rate' }[otc.tableView] || 'Rate';
-                                var tooltip = { 'crude_death_rates': $translate.instant('label.help.text.rate'),
-                                        'age-adjusted_death_rates': $translate.instant('label.help.text.rate')}[otc.tableView] || 'Rate';
+                                var tooltip = { 'crude_death_rates': $translate.instant('label.help.text.crude.rate'),
+                                        'age-adjusted_death_rates': $translate.instant('label.help.text.age.adjusted.rate')}[otc.tableView] || 'Rate';
 
                                 cell += '<span class="owh-table-span" title="'+tooltip+'">' + rateLabel + '</span>';
 

--- a/software/owh/client/app/i18n/messages-en.json
+++ b/software/owh/client/app/i18n/messages-en.json
@@ -415,7 +415,8 @@
   "label.help.text.prams.breakouts.income": "This field indicates the yearly total household income before taxes.",
   "label.help.text.prams.breakouts.marital": "This field indicates the marital status of the mother." ,
 
-  "label.help.text.rate": "Crude Rates are expressed as the number of deaths reported each calendar year per 100,000 population. (Crude Rate = Count / Population * 100,000).",
+  "label.help.text.crude.rate": "Crude Rates are expressed as the number of deaths reported each calendar year per 100,000 population. (Crude Rate = Count / Population * 100,000).",
+  "label.help.text.age.adjusted.rate": "Age-adjusted death rates are weighted averages of the age-specific death rates, where the weights represent a fixed population by age.",
   "label.help.text.prams.breakouts.age.one": "This field indicates the mother's age: Age < 18, Age 18 - 24, Age 25 - 29, Age 30 - 44, Age 45+",
   "label.help.text.prams.breakouts.age.two": "This field indicates the mother's age: Age 18-44.",
   "label.help.text.prams.breakouts.age.three": "This field indicates the mother's age: <20, 20-29, 30+ yrs.",


### PR DESCRIPTION
…the data table

1. Crude death rates  tooltip when hover over on label in datable
![image](https://user-images.githubusercontent.com/23436747/38518746-c860c120-3c0b-11e8-9a58-4846da9a57fb.png)

2. Age adjusted rates tooltip when hover over on label in datable
![image](https://user-images.githubusercontent.com/23436747/38518764-d91c0006-3c0b-11e8-9e39-398887085ada.png)
