### PR TITLE
OWH-2307 For state health factsheets, number of rows under Births Dat…

### DIFF
--- a/software/owh/client/app/modules/factsheet/fact-sheet.controller.js
+++ b/software/owh/client/app/modules/factsheet/fact-sheet.controller.js
@@ -994,6 +994,10 @@
                     ["Birth Rates (per 100,000)", fsc.factSheet.natalityData.birthRate],
                     ["Female  Population (Ages 15 to 44)", $filter('number')(fsc.factSheet.natalityData.femalePopulation)],
                     ["Fertility Rates (per 100,000)", fsc.factSheet.natalityData.fertilityRate],
+                    ['Vaginal rates', fsc.factSheet.natalityData.vaginalRate],
+                    ['Cesarean rates', fsc.factSheet.natalityData.cesareanRate],
+                    ['Low birth weight (<2500 gms)', fsc.factSheet.natalityData.lowBirthWeightRate],
+                    ['Twin birth rate', fsc.factSheet.natalityData.twinBirthRate]
                 ]
             };
             //Tuberculosis


### PR DESCRIPTION
OWH-2307 For state health factsheets, number of rows under Births Dataset is not matching in factsheets and downloaded PDF version

![missing_rows](https://user-images.githubusercontent.com/23436747/38751749-02e3fb50-3f27-11e8-8847-fe6f05559c07.PNG)
